### PR TITLE
Fix: rendering, likes

### DIFF
--- a/src/components/MainHome/HomePostComponent.tsx
+++ b/src/components/MainHome/HomePostComponent.tsx
@@ -23,11 +23,16 @@ export default function HomePostComponent({ post }: prop) {
       <Image source={{ uri: post.thumbnail }} style={styles.picture} />
       {/*{ uri: post.picture } */}
       <View style={styles.textContainer}>
-        <Text style={text.nameText}>{post.name}</Text>
+        <Text style={text.nameText}>{post && post.userName}</Text>
         <Text style={text.titleText}>
           {post.title.length > 23
             ? post.title.substring(0, 23) + '...'
             : post.title}
+        </Text>
+        <Text style={text.contentText}>
+          {post.content.length > 23
+            ? post.content.substring(0, 23) + '...'
+            : post.content}
         </Text>
       </View>
       <View style={styles.profileImageContainer}>

--- a/src/components/MainHome/Styles/HomePostStyle.ts
+++ b/src/components/MainHome/Styles/HomePostStyle.ts
@@ -227,7 +227,7 @@ export const text = {
   },
   contentText: {
     color: '#949494',
-    fontSize: 18,
+    fontSize: 14,
     fontWeight: '400',
     lineHeight: 26,
     letterSpacing: -0.9,

--- a/src/components/ScheduleDetail/bottomsheet.tsx
+++ b/src/components/ScheduleDetail/bottomsheet.tsx
@@ -129,6 +129,7 @@ export default function BottomSheet({
     }
   }
 
+  const { writeDone, setWriteDone } = useSchedule()
   return (
     <PanGestureHandler
       waitFor={[innerGestureHandlerRef]}
@@ -245,6 +246,16 @@ export default function BottomSheet({
                   </View>
                 )
               })}
+            <View style={styles.setCenter}>
+              <TouchableOpacity
+                onPress={() => {
+                  navigation.navigate('WeGoTooOverview')
+                }}
+                style={styles.naviateContainer}
+              >
+                <Text style={text.navigateText}>일정 완료</Text>
+              </TouchableOpacity>
+            </View>
           </ScrollView>
         ) : (
           <View style={{ flex: 1, height: 'auto' }}>

--- a/src/components/ScheduleDetail/styles/bottomSheetStyle.ts
+++ b/src/components/ScheduleDetail/styles/bottomSheetStyle.ts
@@ -39,6 +39,15 @@ export const styles = StyleSheet.create({
     borderRadius: 12,
     borderColor: GlobalStyles.colors.faintGray,
   },
+  naviateContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 389,
+    height: 38,
+    borderRadius: 12,
+    backgroundColor: 'rgba(240, 127, 89, 0.4)',
+    zIndex: 19,
+  },
   contentContainer: {
     position: 'absolute',
     top: 80,
@@ -97,10 +106,12 @@ export const text = {
     letterSpacing: -0.7,
     textDecorationLine: 'underline',
   },
-  businessInfoText: {
+  navigateText: {
     ...baseText,
-    color: '#949494',
+    color: 'white',
     textAlign: 'center',
+    fontSize: 14,
+    fontWeight: 'bold',
   },
 } as {
   [key: string]: StyleProp<TextStyle>

--- a/src/components/ScheduleSpot/scheduleSpotComponent.tsx
+++ b/src/components/ScheduleSpot/scheduleSpotComponent.tsx
@@ -18,7 +18,7 @@ export default function ScheduleSpotComponent({
 }: SpotComponentProp) {
   const navigation = useNavigation()
   //전역 데이터로 받아온 스케줄 아이디
-  const { setScheduleId, scheduleId } = useSchedule()
+  const { setScheduleId, scheduleId, writeDone, setWriteDone } = useSchedule()
   //서버에 호출이 너무 많아서 post state로 관리
   const [hasPosted, setHasPosted] = useState<boolean>(false)
   const handlePostTravelSchedule = async (newCity: string) => {
@@ -28,6 +28,7 @@ export default function ScheduleSpotComponent({
         city: newCity,
       })
       setScheduleId(response.data.scheduleId)
+      setWriteDone(!writeDone)
       console.log('여행 post하고 받아온 id:', scheduleId)
       setHasPosted(true)
     } catch (error) {

--- a/src/context/ScheduleProvide.tsx
+++ b/src/context/ScheduleProvide.tsx
@@ -4,6 +4,8 @@ import React, { createContext, useContext, useState, ReactNode } from 'react'
 export interface ScheduleContextType {
   scheduleId: number | null
   setScheduleId: React.Dispatch<React.SetStateAction<number | null>>
+  writeDone: boolean
+  setWriteDone: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 // ScheduleContext 타입을 명시
@@ -19,9 +21,12 @@ export const useSchedule = () => {
 
 export const ScheduleProvider = ({ children }: { children: ReactNode }) => {
   const [scheduleId, setScheduleId] = useState<number | null>(null)
+  const [writeDone, setWriteDone] = useState<boolean>(false)
 
   return (
-    <ScheduleContext.Provider value={{ scheduleId, setScheduleId }}>
+    <ScheduleContext.Provider
+      value={{ scheduleId, setScheduleId, writeDone, setWriteDone }}
+    >
       {children}
     </ScheduleContext.Provider>
   )

--- a/src/screens/mainhome/HomePostScreen.tsx
+++ b/src/screens/mainhome/HomePostScreen.tsx
@@ -27,7 +27,7 @@ export default function HomePostScreen({ postId }: Postprop) {
       }
     }
     getPostDetail()
-  }, [])
+  }, [liked])
   //날짜를 변환하는 함수
   const formatDate = (isoString: string): string => {
     const date = new Date(isoString)
@@ -44,11 +44,16 @@ export default function HomePostScreen({ postId }: Postprop) {
 
   const handlePostLike = async (postId: number) => {
     try {
-      const data = await postLikes(postId) // postLikes 호출
-      setLiked(true)
-      console.log(data)
+      const data = await postLikes(postId) // 서버에 좋아요 요청
+      if (data.status === 200) {
+        // 서버 응답이 성공하면
+        setLiked(!liked) // 좋아요 상태 업데이트
+        console.log('좋아요 반영됨:', data)
+      }
     } catch (error) {
       console.error('좋아요 실패:', error)
+    } finally {
+      setLiked(!liked)
     }
   }
 

--- a/src/screens/mainhome/HomePostWriteScreen.tsx
+++ b/src/screens/mainhome/HomePostWriteScreen.tsx
@@ -16,7 +16,7 @@ import axios from 'axios'
 import { storePost } from './HomePostHttp'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { RootStackParamList } from '../../../App'
-//import { aaa } from './someOtherFile' // aaa 함수 import
+import { useSchedule } from '@/context/ScheduleProvide'
 
 interface EditPostProps {
   postId: number
@@ -36,7 +36,7 @@ export default function HomePostWriteScreen() {
 
   const [blocks, setBlocks] = useState<Block[]>([{ type: 'T', text: '' }])
 
-  useEffect(() => {}, [])
+  const { writeDone, setWriteDone } = useSchedule()
 
   const handleLeftArrowPress = () => {
     navigation.goBack()
@@ -158,7 +158,7 @@ export default function HomePostWriteScreen() {
       title: title,
       contents: blocks,
     }
-
+    setWriteDone(!writeDone)
     console.log('postData확인', postData)
     const id = await storePost(postData)
     console.log('postId여기서도 확인되?', id)

--- a/src/screens/mainhome/MainHomeScreen.tsx
+++ b/src/screens/mainhome/MainHomeScreen.tsx
@@ -14,13 +14,14 @@ import { useFocusEffect } from '@react-navigation/native'
 import { useState, useCallback } from 'react'
 import { getHomePost } from '@/api/Home/getHomePostApi'
 import { GlobalStyles } from '@/constants/colors'
+import { useSchedule } from '@/context/ScheduleProvide'
 
 export default function MainHomeScreen() {
   const [posts, setPosts] = useState<HomePostType[]>([])
   const [page, setPage] = useState(1) // 현재 페이지
   const [isLoading, setIsLoading] = useState(false) // 로딩 상태
   const [hasMore, setHasMore] = useState(true) // 더 불러올 데이터가 있는지 여부
-
+  const { writeDone } = useSchedule()
   // 서버로부터 게시글 목록을 가져오는 함수
   const fetchPosts = async (currentPage: number) => {
     try {
@@ -33,7 +34,7 @@ export default function MainHomeScreen() {
         setHasMore(false)
       } else {
         // 기존 posts에 새로 가져온 게시글을 추가
-        setPosts((prevPosts) => [...prevPosts, ...response.content])
+        setPosts((prevPosts) => [...response.content, ...prevPosts])
       }
     } catch (error) {
       console.log('Error fetching posts:', error)
@@ -46,7 +47,7 @@ export default function MainHomeScreen() {
   useFocusEffect(
     useCallback(() => {
       fetchPosts(page)
-    }, [page]), // 페이지가 바뀔 때마다 실행
+    }, [page, writeDone]), // 페이지가 바뀔 때마다 실행
   )
 
   // 스크롤이 끝에 도달했는지 확인하는 함수

--- a/src/screens/schedule/ScheduleHomeScreen.tsx
+++ b/src/screens/schedule/ScheduleHomeScreen.tsx
@@ -16,19 +16,24 @@ import { Schedule } from '@/types/ScheduleHomeType'
 import FloatingButton from '@/components/Common/floatingButton'
 import { getScheduleHome } from '@/api/Schedule/getScheduleHome'
 import { GlobalStyles } from '@/constants/colors'
+import { useSchedule } from '@/context/ScheduleProvide'
+
 export default function ScheduleHome() {
   const [plans, setPlans] = useState<Schedule[]>([]) // 여행 일정 데이터
   const [page, setPage] = useState(1) // 현재 페이지
   const [isLoading, setIsLoading] = useState(false) // 로딩 상태
   const [hasMore, setHasMore] = useState(true) // 더 불러올 데이터가 있는지 여부
+  const [size, setSize] = useState(4) // 기본 사이즈
+  const { writeDone, setWriteDone } = useSchedule()
 
   const handleSchedule = async (currentPage: number) => {
     try {
       setIsLoading(true) // 로딩 상태 설정
-      const response = await getScheduleHome(currentPage, 4) // API 호출 (페이지당 4개씩)
-
+      const response = await getScheduleHome(currentPage, size) // API 호출 (페이지당 4개씩)
+      console.log('서버에 호출이 가나?')
       if (response.data.content.length > 0) {
-        setPlans((prevPlans) => [...prevPlans, ...response.data.content]) // 이전 데이터와 병합
+        setPlans((prevPlans) => [...response.data.content, ...prevPlans]) // 이전 데이터와 병합
+        console.log('pans??', plans)
       } else {
         setHasMore(false) // 더 이상 불러올 데이터가 없을 때
       }
@@ -38,6 +43,7 @@ export default function ScheduleHome() {
       setIsLoading(false) // 로딩 완료
     }
   }
+
   // 스크롤이 끝에 도달했는지 확인하는 함수
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent
@@ -47,12 +53,16 @@ export default function ScheduleHome() {
       setPage((prevPage) => prevPage + 1) // 페이지 번호 증가
     }
   }
-  // 페이지가 변경될 때마다 새로운 데이터를 가져오기
+
   useFocusEffect(
     useCallback(() => {
       handleSchedule(page)
-    }, [page]),
+
+      console.log('포커스르 받나?')
+    }, [page, writeDone]),
   )
+  // 페이지가 변경되거나 화면이 포커스되었을 때 데이터 가져오기
+
   return (
     <View style={styles.container}>
       {/* 헤더 */}

--- a/src/screens/schedule/SchedulePlaceSearch.tsx
+++ b/src/screens/schedule/SchedulePlaceSearch.tsx
@@ -36,8 +36,7 @@ export default function PlaceSearchComponent({
   date,
 }: PlaceSearchprop) {
   const navigation = useNavigation()
-
-  const { scheduleId } = useSchedule()
+  const { scheduleId, writeDone, setWriteDone } = useSchedule()
   console.log(detailedId, '아이디값 검색창에 잘 옴')
 
   const [name, setName] = useState<string>()
@@ -55,6 +54,7 @@ export default function PlaceSearchComponent({
         longitude: longitude,
       }
       console.log('보낼 상세 계획 데이터:', newSchedule)
+      setWriteDone(!writeDone)
       try {
         // 버튼이 눌렸을 때 post 요청
         await postDetailedSchedule(newSchedule, detailedId)

--- a/src/types/HomePostType.ts
+++ b/src/types/HomePostType.ts
@@ -1,7 +1,8 @@
 interface HomePostType {
   postId: number
   title: string
-  name: string
+  userName: string
   userProfileImage: string
   thumbnail: string
+  content: string
 }


### PR DESCRIPTION
### Summary

좋아요 화면 반영 이슈는 정말 어이없게도 state 변화를 줘놓고 의존성 배열에 넣어놓지 않았서 발생하는 문제였습니다.

홈화면에 일정이나 게시글이 바로 보이지 않았던 건 서버에 api호출을 해서 받아올 때 스크롤에 따라 페이지값을 달리해서 받아오는데 이때 Plans 상태를 업데이트할 때 기존에 받아온 데이터를 배열에 결합하는 과정에서 기존의 배열데이터를 앞에 스프래드 했기 때문에 당연히 새로 받아온 데이터가 뒤로 밀려 안보이는 것이었습니다.  그래서 아예 로그인을 다시하는 것처럼 컴포넌트가 마운트가 되면서 서버에서 정렬된 데이터를 받아온 첫순간에만 새 게시물이 보였던 것입니다....ㅋㅎ
setPosts((prevPosts) => [...prevPosts,...response.conten]) 에서 
setPosts((prevPosts) => [...response.content, ...prevPosts])로 바꿨습니다. 

지금 확인 결과 게시글 홈과 일정 홈 모두 최근 사항이 반영됩니다. 

### Notice 
게시글 홈 컴포넌트에 기존 타입 정의와 서버에서 내려주는 값이 달랐던 부분 디자인이 약간 추가되었습니다.