### PR TITLE
Refactor:googlePlaceSearch

### DIFF
--- a/src/api/Schedule/getScheduleHome.ts
+++ b/src/api/Schedule/getScheduleHome.ts
@@ -5,7 +5,6 @@ import { apiClient } from '../apiClient'
 export const getScheduleHome = async (page: number, size: number) => {
   try {
     let token = await AsyncStorage.getItem('accessToken')
-
     const response = await apiClient.get(
       `/schedules?page=${page}&size=${size}`,
       {

--- a/src/screens/schedule/ScheduleDetailScreen.tsx
+++ b/src/screens/schedule/ScheduleDetailScreen.tsx
@@ -103,12 +103,15 @@ export default function ScheduleDetail() {
     }
   }
   const [plans, setPlans] = useState<PlanData[]>([])
+
   const handleDetailedSchedule = async () => {
     if (!scheduleId) return // scheduleId가 없으면 함수 종료
     try {
       const response = await getDetailedPlans(scheduleId)
       setPlans(response.data) // 상태 업데이트
-      setPlanLength(response.data.length) // 배열 길이 저장
+
+      setShouldRerender(false)
+
       console.log(response.data, '받아온 plans')
     } catch (error) {
       console.error('Error Getting travel schedule:', error)
@@ -119,9 +122,8 @@ export default function ScheduleDetail() {
     useCallback(() => {
       if (scheduleId) {
         handleDetailedSchedule()
-        shouldRerender && setShouldRerender(!shouldRerender)
       }
-    }, [scheduleId]),
+    }, [scheduleId, shouldRerender]),
   )
 
   //plans를 넣으면 plans가 배열이어서 같은 배열임에도 불구하고 계속 state가 변했다고 생각함 그래서 서버에 호출을 계속 보냄

--- a/src/screens/schedule/ScheduleDetailScreen.tsx
+++ b/src/screens/schedule/ScheduleDetailScreen.tsx
@@ -121,7 +121,7 @@ export default function ScheduleDetail() {
         handleDetailedSchedule()
         shouldRerender && setShouldRerender(!shouldRerender)
       }
-    }, [scheduleId, shouldRerender]),
+    }, [scheduleId]),
   )
 
   //plans를 넣으면 plans가 배열이어서 같은 배열임에도 불구하고 계속 state가 변했다고 생각함 그래서 서버에 호출을 계속 보냄

--- a/src/screens/schedule/ScheduleDetailScreen.tsx
+++ b/src/screens/schedule/ScheduleDetailScreen.tsx
@@ -91,7 +91,7 @@ const dummy = [
 ]
 
 export default function ScheduleDetail() {
-  const { scheduleId = 0 } = useSchedule()
+  const { scheduleId = 0, writeDone } = useSchedule()
   //메모 작성 이후 ui 반영이 바로 안됨
   const [shouldRerender, setShouldRerender] = useState(false)
   console.log('스케줄 아이디 상세페이지에서 어떻게 받아와지나', scheduleId)
@@ -123,7 +123,7 @@ export default function ScheduleDetail() {
       if (scheduleId) {
         handleDetailedSchedule()
       }
-    }, [scheduleId, shouldRerender]),
+    }, [scheduleId, shouldRerender, writeDone]),
   )
 
   //plans를 넣으면 plans가 배열이어서 같은 배열임에도 불구하고 계속 state가 변했다고 생각함 그래서 서버에 호출을 계속 보냄

--- a/src/screens/schedule/ScheduleHomeScreen.tsx
+++ b/src/screens/schedule/ScheduleHomeScreen.tsx
@@ -33,7 +33,7 @@ export default function ScheduleHome() {
       console.log('서버에 호출이 가나?')
       if (response.data.content.length > 0) {
         setPlans((prevPlans) => [...response.data.content, ...prevPlans]) // 이전 데이터와 병합
-        console.log('pans??', plans)
+        console.log('pans??', response.data.content)
       } else {
         setHasMore(false) // 더 이상 불러올 데이터가 없을 때
       }
@@ -57,8 +57,7 @@ export default function ScheduleHome() {
   useFocusEffect(
     useCallback(() => {
       handleSchedule(page)
-
-      console.log('포커스르 받나?')
+      setPage(1)
     }, [page, writeDone]),
   )
   // 페이지가 변경되거나 화면이 포커스되었을 때 데이터 가져오기

--- a/src/screens/schedule/SchedulePlaceSearch.tsx
+++ b/src/screens/schedule/SchedulePlaceSearch.tsx
@@ -54,7 +54,7 @@ export default function PlaceSearchComponent({
         longitude: longitude,
       }
       console.log('보낼 상세 계획 데이터:', newSchedule)
-      setWriteDone(!writeDone)
+      setWriteDone(!writeDone) //바텀시트에 바로 반영이 되도록
       try {
         // 버튼이 눌렸을 때 post 요청
         await postDetailedSchedule(newSchedule, detailedId)

--- a/src/screens/schedule/SchedulePlaceSearch.tsx
+++ b/src/screens/schedule/SchedulePlaceSearch.tsx
@@ -102,9 +102,9 @@ export default function PlaceSearchComponent({
           // } else {
           //   console.log('No photos available for this place')
           // }
-          if (latitude && longitude && name && scheduleId) {
-            navigation.navigate('SceduleDetail' as never)
-          }
+
+          //상세일정에서 서버에 데이터를 호출할 때 포커스시에 데이터 요청을 하고 state를 리렌더링하기 때문에 조건 아래에서 네비게이션을 해줄 필요가 없었음
+          navigation.navigate('SceduleDetail' as never)
         }}
         query={{
           key: GOOGLE_PLACES_API_KEY,

--- a/src/screens/schedule/map.tsx
+++ b/src/screens/schedule/map.tsx
@@ -47,13 +47,20 @@ export default function AppleMap({ plans }: Props) {
       // 위치가 변경되었을 때, 상태를 업데이트하여 MapView의 region 변경
       if (plans && plans[0] && plans[0].detailedPlans) {
         setRegion({
-          latitude: plans[0].detailedPlans[0].latitude, // 기본 좌표 (서울)
-          longitude: plans[0].detailedPlans[0].longitude, // 기본 좌표 (서울)
+          latitude: plans[0].detailedPlans[0].latitude,
+          longitude: plans[0].detailedPlans[0].longitude,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        })
+      } else {
+        setRegion({
+          latitude: 37.5665,
+          longitude: 126.978,
           latitudeDelta: 0.1,
           longitudeDelta: 0.1,
         })
       }
-    }, [plans]),
+    }, [plans, scheduleId]), //일정 세울 때 이전 일정의 위도,경도와 데이터를 받아와서 스케줄 아이디가 변경시에 다시 리랜더링 되게함
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
제가 이전에는 장소 검색시에 구글에서 위도, 경도, 장소 이름 정보 등을 서버에 보내야하니까 받아온 후에 상세일정에 네비게이션이 되어야한다고 생각했는데 생각하다보니 해당 정보들을 받아오지 않은 상태에서 상세일정 페이지로 넘어가더라도 페이지가 포커스를 받으면 서버에서 데이터를 호출하니까. 서버에 데이터를 보내는 거랑 상관없이 페이지 이동이 되게끔 하는게 나을 것 같더라구요.  이제는 누르면 바로 화면 이동이 됩니다.

리렌더 state를 필요없다고 생각해서 지웠었는데 전에 memopsot api를 보냈을 때 state를 바꾸고 일정 받아오는 sueFocusEffect의 의존성 배열에 넣어놨던 거라 다시 추가했습니다!

스케줄 홈에서 최신 사항이 반영이 안됐었던 건 scroll에 따른 page변화 때문이었습니다. 포커스 될 때마다 page state를 1로 다시 바꿔주었더니 최신 일정이 상단에 보이고 있습니다.


### CheckList
src/screens/schedule/SchedulePlaceSearch.tsx